### PR TITLE
Add Name to be used in From address

### DIFF
--- a/send.go
+++ b/send.go
@@ -17,6 +17,7 @@ import (
 type Email struct {
 	Subject, Body string
 	From          string
+	Name          string
 	Password      string
 	ContentType   string
 	To            []string
@@ -128,6 +129,10 @@ func (e *Email) Bytes() []byte {
 
 	buf.WriteString("Subject: " + e.Subject + "\n")
 	buf.WriteString("MIME-Version: 1.0\n")
+
+	if e.Name != "" {
+		buf.WriteString(fmt.Sprintf("From: %s <%s>\n", e.Name, e.From))
+	}
 
 	// Boundary is used by MIME to separate files.
 	boundary := "f46d043c813270fc6b04c2d223da"


### PR DESCRIPTION
I've noticed that we can send emails only with the address of the account.

For example, if I send a mail using the user admin@gmail.com, the recipient would see **admin** as the sender in his inbox.

To avoid that, we usually use in the mail header "From: Name Surname <admin@gmail.com>", but, as the code used the From field for the username credentials, if I just put this string in this field, we wouldn't be able to log in.

I've created a new field called Name, if this field is filled by the user, I will add a new header From to customize the email body details.

